### PR TITLE
[src] Add type traits for matrix templating

### DIFF
--- a/matrix/CMakeLists.txt
+++ b/matrix/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_executable(matrix src/main.cpp src/matrix.cpp include/matrix.hpp)
+add_executable(matrix src/main.cpp src/matrix.cpp include/matrix.hpp include/number_trait.hpp)
 
 target_include_directories(matrix PRIVATE include src)
 

--- a/matrix/include/number_trait.hpp
+++ b/matrix/include/number_trait.hpp
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "rationals.hpp"
+
+template<typename T>
+struct is_number {
+  static const bool value = false;
+};
+
+template<>
+struct is_number<unsigned short> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<short> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<unsigned int> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<int> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<unsigned long> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<long> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<unsigned long long> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<float> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<double> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<long double> {
+  static const bool value = true;
+};
+
+template<>
+struct is_number<mmath::Rational> {
+  static const bool value = true;
+};


### PR DESCRIPTION
### Description of the PR
This PR adds the type trait `is_number` for a matrix. This type trait ensures any type used with a matrix can be used in a mathematical sense.

Types used in the type trait: short, int, long, long long, float, double, long double